### PR TITLE
Add bar graph to display

### DIFF
--- a/gruntfile.js
+++ b/gruntfile.js
@@ -1,5 +1,5 @@
 module.exports = function (grunt) {
-    
+
     grunt.initConfig({
 
     	path: {
@@ -32,6 +32,7 @@ module.exports = function (grunt) {
 			build: {
 				files: {
 				    '<%= path.dist.scripts %>scripts.js': [
+                        '<%= path.vendor %>d3/d3.js',
 				    	'<%= path.vendor %>jquery/dist/jquery.js',
 				    	'<%= path.vendor %>bootstrap/js/dropdown.js',
 				    	'<%= path.vendor %>bootstrap/js/modal.js',
@@ -113,7 +114,7 @@ module.exports = function (grunt) {
 		},
 
 		simplemocha: {
-			all: { 
+			all: {
 				src: '<%= path.test %>**/*.js'
 			}
 		},
@@ -133,7 +134,7 @@ module.exports = function (grunt) {
 			},
 			less: {
 				files: ['<%= path.src.less %>**/*.less'],
-				tasks: ['less', 'cssmin'] 
+				tasks: ['less', 'cssmin']
 			},
 			image: {
 				files: ['<%= path.src.images %>**/*.{png,jpg,gif}'],
@@ -147,7 +148,7 @@ module.exports = function (grunt) {
 	grunt.loadNpmTasks('grunt-contrib-uglify');
 	grunt.loadNpmTasks('grunt-contrib-watch');
 	grunt.loadNpmTasks('grunt-contrib-imagemin');
-	grunt.loadNpmTasks('grunt-contrib-cssmin');	
+	grunt.loadNpmTasks('grunt-contrib-cssmin');
 	grunt.loadNpmTasks('grunt-contrib-clean');
 	grunt.loadNpmTasks('grunt-contrib-copy');
 	grunt.loadNpmTasks('grunt-contrib-less');

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "grunt-contrib-watch": "^0.6.1",
     "grunt-simple-mocha": "^0.4.0",
     "jquery": "1.11.3",
-    "mocha": "^2.2.5"
+    "mocha": "^2.2.5",
+    "d3": "^3.5.6"
   }
 }

--- a/web/public/source/less/app.less
+++ b/web/public/source/less/app.less
@@ -5,21 +5,21 @@
 	This file is part of Wii-Scale
 
 	----------------------------------------------------------------------------
-	
+
 	The MIT License (MIT)
-	
+
 	Copyright (c) 2015 Andreas Älveborn
-	
+
 	Permission is hereby granted, free of charge, to any person obtaining a copy
 	of this software and associated documentation files (the "Software"), to deal
 	in the Software without restriction, including without limitation the rights
 	to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 	copies of the Software, and to permit persons to whom the Software is
 	furnished to do so, subject to the following conditions:
-	
+
 	The above copyright notice and this permission notice shall be included in all
 	copies or substantial portions of the Software.
-	
+
 	THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 	IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 	FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -32,7 +32,7 @@
 
 // App
 body {
-	background-color: #fdfdfd;	
+	background-color: #fdfdfd;
 	font-family: 'Open Sans', sans-serif;
 	font-weight: lighter;
 }
@@ -47,12 +47,45 @@ h1, h2, h3, h4, h5, h6 {
 	font-weight: lighter;
 }
 
+.svg-container {
+	display: inline-block;
+	position: relative;
+	width: 100%;
+	padding-bottom: 100%; /* aspect ratio */
+	vertical-align: top;
+	overflow: hidden;
+}
+
+.svg-content-responsive {
+	display: inline-block;
+	position: absolute;
+	top: 10px;
+	left: 0;
+}
+
+graph rect {
+	fill: steelblue;
+}
+
+.axis path,
+.axis line {
+	fill: none;
+	stroke: #3c3c3c;
+	shape-rendering: crispEdges;
+}
+
 .clearfix {
 	&:after {
 		content:"";
 		display:table;
 		clear:both;
 	}
+}
+
+text.bar-text {
+	shape-rendering: crispEdges;
+	font-family: 'Open Sans', sans-serif;
+	color: white;
 }
 
 /* Animations */
@@ -111,7 +144,7 @@ h1, h2, h3, h4, h5, h6 {
 		-webkit-transition: all linear 0.2s;
 		transition: all linear 0.2s;
 	}
-	
+
 	&.ng-hide-add {
 		-webkit-transition: none;
 		transition: none;
@@ -292,7 +325,7 @@ h1, h2, h3, h4, h5, h6 {
 						.dropdown-header {
 							padding-left: 15px;
 						}
-					}	
+					}
 				}
 			}
 		}

--- a/web/public/source/less/app.less
+++ b/web/public/source/less/app.less
@@ -67,13 +67,6 @@ graph rect {
 	fill: steelblue;
 }
 
-.axis path,
-.axis line {
-	fill: none;
-	stroke: #3c3c3c;
-	shape-rendering: crispEdges;
-}
-
 .clearfix {
 	&:after {
 		content:"";
@@ -85,7 +78,7 @@ graph rect {
 text.bar-text {
 	shape-rendering: crispEdges;
 	font-family: 'Open Sans', sans-serif;
-	color: white;
+	fill: white;
 }
 
 /* Animations */

--- a/web/public/source/scripts/directives.js
+++ b/web/public/source/scripts/directives.js
@@ -5,21 +5,21 @@
     This file is part of Wii-Scale
 
     ----------------------------------------------------------------------------
-    
+
     The MIT License (MIT)
-    
+
     Copyright (c) 2015 Andreas Älveborn
-    
+
     Permission is hereby granted, free of charge, to any person obtaining a copy
     of this software and associated documentation files (the "Software"), to deal
     in the Software without restriction, including without limitation the rights
     to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
     copies of the Software, and to permit persons to whom the Software is
     furnished to do so, subject to the following conditions:
-    
+
     The above copyright notice and this permission notice shall be included in all
     copies or substantial portions of the Software.
-    
+
     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
     IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
     FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -112,6 +112,115 @@
                             return;
                         }
                         controlsHandler();
+                    });
+                }
+            };
+        }]).
+
+        directive('graph', ['entries', function (entries){
+            return {
+                scope: {
+                    entries: '='
+                },
+                restrict: 'E',
+                replace: false,
+                link: function($scope, iElm, iAttrs, controller) {
+
+                    var margin = {top: 10, right: 10, bottom: 10, left: 10},
+                    width = 700 - margin.left - margin.right,
+                    height = 450 - margin.top - margin.bottom;
+
+                    var defaultQuantity = 21;
+                    var barWidth = width / defaultQuantity;
+                    var svg = d3.select(iElm[0])
+                        .append('svg')
+                        .classed('svg-content-responsive', true)
+                        .attr('viewBox', function(){ return '0 0 ' + (width) +' ' + (height); })
+                        .attr('preserveAspectRatio', 'xMinYMin meet');
+
+                    var barGraph = null;
+
+                    function graphHandler() {
+                        var data = $scope.entries.list.length > defaultQuantity ? $scope.entries.list.slice(-defaultQuantity) : $scope.entries.list;
+
+                        var x = d3.time.scale()
+                        	        .range([0, width])
+                        	        .domain([ d3.min(data, function(d){ return +(new Date(d.dateTime));} ),
+                    	                      d3.max(data, function(d){ return +(new Date(d.dateTime));} )]);
+                    	var y = d3.scale.linear()
+                    	            .range([height, 0])
+                    	            .domain([25, 140]).nice();
+
+                        if (barGraph === null) {
+                            barGraph = svg.append('g')
+                                .classed('bar-graph', true);
+                        }
+
+                        // DATA JOIN
+                        // Join new data with any existing elements
+                        var bars = barGraph.selectAll('g').data(data);
+
+                        // UPDATE
+                        // Update existing elements with new values
+                        bars.transition()
+                            .duration(750)
+                            .attr("transform", function(d, i) { return "translate(" + (defaultQuantity - 1 - i) * barWidth + ",0)"; });
+
+                        bars.select('rect')
+                            .attr("height", function(d) { return height - y(d.weight); })
+                            .transition()
+                            .duration(750)
+                                .attr("y", function(d) { return y(d.weight); });
+
+                        bars.select('text')
+                            .attr("y", -barWidth / 4)
+                            .text(function(d) { return d.weight + " kg"; })
+                            .transition()
+                            .duration(750)
+                                .attr("x", function(d) { return y(d.weight) + 5; });
+
+                        // ENTER
+                        // Create new elements as required
+                        var barsEnter = bars.enter()
+                                    .append('g')
+                                    .attr("transform", function(d, i) { return "translate(" + (defaultQuantity - 1 - i) * barWidth + ",0)"; });
+
+                        barsEnter.append('rect')
+                            .attr("y", function(d) { return y(d.weight); })
+                            .attr("width", barWidth - 1)
+                            .style('fill-opacity', 1e-6)
+                            .transition()
+                            .duration(750)
+                                .attr("height", function(d) { return height - y(d.weight); })
+                                .style('fill-opacity', 1);
+
+                        barsEnter.append('text')
+                            .attr("y", -(barWidth / 4) + 2)
+                            .attr('text-anchor', 'start')
+                            .attr('transform', 'rotate(90)')
+                            .classed('bar-text', true)
+                            .text(function(d) { return d.weight + " kg"; })
+                            .style('fill-opacity', 1e-6)
+                            .transition()
+                            .duration(750)
+                                .attr("x", function(d) { return y(d.weight) + 5; })
+                                .style('fill-opacity', 1);
+
+                        // EXIT
+                        // Remove elements that are no longer present in the data
+                        bars.exit()
+                            .transition()
+                            .duration(500)
+                                .style('fill-opacity', 1e-6)
+                            .remove();
+
+                    }
+
+                    $scope.$watch('entries.list.length', function(newValue, oldValue) {
+                        if(newValue === undefined) {
+                            return;
+                        }
+                        graphHandler();
                     });
                 }
             };

--- a/web/public/views/partials/start.html
+++ b/web/public/views/partials/start.html
@@ -5,21 +5,21 @@
     This file is part of Wii-Scale
 
     ----------------------------------------------------------------------------
-    
+
     The MIT License (MIT)
-    
+
     Copyright (c) 2015 Andreas Älveborn
-    
+
     Permission is hereby granted, free of charge, to any person obtaining a copy
     of this software and associated documentation files (the "Software"), to deal
     in the Software without restriction, including without limitation the rights
     to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
     copies of the Software, and to permit persons to whom the Software is
     furnished to do so, subject to the following conditions:
-    
+
     The above copyright notice and this permission notice shall be included in all
     copies or substantial portions of the Software.
-    
+
     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
     IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
     FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -36,7 +36,7 @@
 	            <a class="navbar-brand" href="/">
 	                Wii-Scale
 	            </a>
-	        </div>	        
+	        </div>
 
 	        <ul class="nav navbar-nav navbar-right nav-controls">
 	            <li>
@@ -54,7 +54,7 @@
 	        </ul>
 
 			<div ng-controller="UserController">
-				
+
 				<delete-user-modal user="users.removeUser"></delete-user-modal>
 
 		        <ul class="nav navbar-nav navbar-right nav-users">
@@ -74,7 +74,7 @@
 								</a>
 							</li>
 
-							<li ng-repeat="user in users.list track by $index">							
+							<li ng-repeat="user in users.list track by $index">
 								<a href="#">
 									<i class="fa fa-trash-o" ng-click="users.remove(user)"
 										data-toggle="modal" data-target="#deleteUserModal"></i>
@@ -98,7 +98,7 @@
 	    </div>
 	</nav>
 
-	<div class="container-fluid">        
+	<div class="container-fluid">
 
 	    <div class="row">
 	        <div class="col-xs-12 status-bar">
@@ -143,7 +143,7 @@
 	                    Disconnecting
 	                </p>
 	            </status>
-	            
+
 	            <status type="warning" ng-show="status.warning">
 	                <i class="fa fa-exclamation-triangle"></i>
 	                <p>
@@ -165,6 +165,13 @@
 	                <span class="value" id="weight-total">{{ measuring.weight | number:1 }}</span>
 	                <span class="unit">kg</span>
 	            </div>
+				<div class="row">
+
+					<div class="col-xs-12">
+						<graph entries="entries" class="svg-container"></graph>
+					</div>
+
+				</div>
 	        </div>
 
 	        <div class="col-xs-12 col-md-4 col-md-offset-1">
@@ -176,6 +183,7 @@
 	        </div>
 
 	    </div>
+
 	</div>
 
 </div>


### PR DESCRIPTION
This adds a graph of the last 21 user weight entries to the display.

It uses d3.js to generate an SVG bar graph.  When entries are added or removed the graph will update as required.  SVG should be responsive in size across different display sizes.

It uses the D3 update, enter, exit general update pattern to re-use elements or add & remove them when data changes.

![screen shot 2015-07-25 at 1 46 31 pm](https://cloud.githubusercontent.com/assets/1689878/8887772/d4208b2e-32d3-11e5-9a0c-72352a045352.png)
